### PR TITLE
Update and improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 FROM ruby
 
-# install travis-cli
-RUN gem install travis --no-rdoc --no-ri
+RUN \
+        # install sudo (used by generated script)
+        apt-get update && apt-get install sudo && \
+        # install travis-cli
+        gem install travis --no-rdoc --no-ri && \
+        # install bundler
+        gem install bundler && \
+        # install travis-build
+        git clone --depth 1 https://github.com/travis-ci/travis-build.git /opt/travis-build && \
+        bundle install --gemfile /opt/travis-build/Gemfile && \
+        mkdir $HOME/.travis && \
+        ln -s /opt/travis-build $HOME/.travis/travis-build
 
-# install travis-build
-RUN git clone https://github.com/travis-ci/travis-build.git /opt/travis-build
-RUN mkdir /root/.travis
-RUN ln -s /opt/travis-build $HOME/.travis/travis-build
-
-RUN travis version
-
-ENTRYPOINT ["travis", "run", "--skip-version-check", "--skip-completion-check"]
-CMD ["-p"]
-
+WORKDIR /data
+COPY run.sh /root/
+ENTRYPOINT ["/root/run.sh"]

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@ IMAGE_NAME := tomdesinto/travis-run
 
 build:
 	docker build --rm -t $(IMAGE_NAME) .
-	
+
 run:
-	@echo docker run --rm -it -v $$(pwd):/data $(IMAGE_NAME) 
-	
+	@echo docker run --rm -it -v $$(pwd):/data $(IMAGE_NAME)
+
 shell:
 	docker run --rm -it -v $$(pwd):/data --entrypoint bash $(IMAGE_NAME) -l

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+travis compile --skip-version-check --skip-completion-check "$@" > run-travis.sh
+chmod u+x ./run-travis.sh
+./run-travis.sh


### PR DESCRIPTION
- Travis build now has a compile command rather than run, which echoes
  a bash script that you have to run yourself. See [#353](travis-ci/travis-build#353).
- Reduce image size with only one RUN layer.
- Install gems with bundler.

Docker-travis-run's approach isn't going to work for me since the cookbook I want to use modifies /etc/hosts, which doesn't really exist in docker. I'm probably going to use [worker](https://github.com/travis-ci/worker) instead, so I shoved all the changes I made into one branch for you to do with what you will. You might just want to take the stuff pertinent to the run/compile change.
